### PR TITLE
Add support for GPR files

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -10,6 +10,14 @@ schema_version = 1
 repository = "https://github.com/briot/tree-sitter-ada"
 commit = "e8e2515465cc2d7c444498e68bdb9f1d86767f95"
 
+[grammars.gpr]
+repository = "https://github.com/brownts/tree-sitter-gpr"
+commit = "cea857d3c18d1385d1f5b66cd09ea1e44173945c"
+
 [language_servers.als]
 name = "Ada Language Server"
 language = "Ada"
+
+[language_servers.als_gpr]
+name = "Ada Language Server (GPR)"
+languages = ["GPR"]

--- a/languages/gpr/config.toml
+++ b/languages/gpr/config.toml
@@ -1,0 +1,9 @@
+name = "GPR"
+grammar = "gpr"
+path_suffixes = ["gpr"]
+line_comments = ["-- "]
+tab_size = 3
+brackets = [
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/languages/gpr/highlights.scm
+++ b/languages/gpr/highlights.scm
@@ -1,0 +1,59 @@
+;; Adapted from queries/highlights.scm in the grammar repository.
+[
+    "abstract"
+    "all"
+    "at"
+    "case"
+    "end"
+    "extends"
+    "external"
+    "external_as_list"
+    "for"
+    "is"
+    "limited"
+    "null"
+    "others"
+    "package"
+    ;; "project"
+    "renames"
+    "type"
+    "use"
+    "when"
+    "with"
+] @keyword
+
+;; Avoid highlighting Project in Project'Project_Dir
+(project_declaration "project" @keyword)
+
+;; highlight qualifiers as keywords (not all qualifiers are actual keywords)
+(project_qualifier _ @keyword)
+
+[":=" "&" "|" "=>"] @operator
+
+(comment) @comment
+(string_literal) @string
+(numeric_literal) @number
+
+;; Type
+(typed_string_declaration name: (identifier) @type)
+(variable_declaration type: (name (identifier) @type .))
+
+;; Variable
+(variable_declaration name: (identifier) @variable)
+(variable_reference (name (identifier) @variable .) .)
+
+;; Function
+(builtin_function_call name: _ @function.builtin)
+
+;; Attribute
+(attribute_declaration name: (identifier) @attribute)
+(attribute_reference (identifier) @attribute)
+
+;; Package
+(variable_reference (name (identifier) @function .) "'")
+(package_declaration [
+    name: (identifier) @function
+    endname: (identifier) @function
+    origname: (name (identifier) @function .)
+    basename: (name (identifier) @function .)
+])


### PR DESCRIPTION
Only syntax highlighting and LSP support are provided for now. The former uses the highlight queries from the grammar, the latter is based on `ada_language_server --language-gpr`.